### PR TITLE
fix n_up, n_down in qmcpack interface

### DIFF
--- a/Interfaces/WriteEshdf.cpp
+++ b/Interfaces/WriteEshdf.cpp
@@ -371,6 +371,7 @@ void eshdfFile::writeElectrons(void) {
             hid_t dn_spin_group = makeHDFGroup("spin_1", kpt_group);
             handleSpinGroup(i, nspin-1, dn_spin_group, ndn, fftCont);
         } else {
+            nup *= 0.5;
             ndn = nup;
         }
 


### PR DESCRIPTION
for spin-restricted (non-polarized) calculations, N_up and N_down were both being set to the total number of electrons