### PR TITLE
Update to include number of steps to converge in energy test.

### DIFF
--- a/Headers/rmg_control.h
+++ b/Headers/rmg_control.h
@@ -993,6 +993,8 @@ public:
    double test_energy_tolerance=1.0e-7;
    double test_bond_length=NAN;
    double test_bond_length_tolerance=1.0e-3;
+   int test_steps=0;
+   int test_steps_tolerance=0;
 
 };
 

--- a/Input/ReadCommon.cpp
+++ b/Input/ReadCommon.cpp
@@ -1045,15 +1045,20 @@ void ReadCommon(char *cfile, CONTROL& lc, PE_CONTROL& pelc, std::unordered_map<s
             "Expected final energy for testing. ",
             "test_energy must lie in the range (-1.0e9,1.0e9). Ignoring. ", TESTING_OPTIONS);
 
-    If.RegisterInputKey("epsg_guard", &lc.epsg_guard, 0.0, 1.0e-5, 1.0e-7,
-            CHECK_AND_FIX, OPTIONAL,
-            "GGA guard value for low density regions. ",
-            "epsg_guard must lie in the range (0.0,1.0e-5). Ignoring. ", CONTROL_OPTIONS);
-
     If.RegisterInputKey("test_energy_tolerance", &lc.test_energy_tolerance, 1.0e-8, 1.0e-4, 1.0e-7,
             CHECK_AND_FIX, OPTIONAL,
             "Test final energy tolerance. ",
             "test_energy_tolerance must lie in the range (1.0e-8,1.0e-4). Resetting to the default value of 1.0e-7. ", TESTING_OPTIONS);
+
+    If.RegisterInputKey("test_steps", &lc.test_steps, 0, 1000, 0,
+            CHECK_AND_FIX, OPTIONAL,
+            "Expected number of scf steps for testing. ",
+            "test_steps must lie in the range (0,1000). Ignoring. ", TESTING_OPTIONS);
+
+    If.RegisterInputKey("test_steps_tolerance", &lc.test_steps_tolerance, 0, 10, 1,
+            CHECK_AND_FIX, OPTIONAL,
+            "Test scf steps tolerance. ",
+            "test_steps_tolerance must lie in the range (0,10). Ignoring. ", TESTING_OPTIONS);
 
     If.RegisterInputKey("test_bond_length", &lc.test_bond_length, 0.0 , 20.0, (double)NAN,
             CHECK_AND_FIX, OPTIONAL,
@@ -1064,6 +1069,11 @@ void ReadCommon(char *cfile, CONTROL& lc, PE_CONTROL& pelc, std::unordered_map<s
             CHECK_AND_FIX, OPTIONAL,
             "Test bond length tolerance. ",
             "test_bond_length_tolerance must lie in the range (1.0e-4,1.0e-1). Resetting to the default value of 1.0e-3. ", TESTING_OPTIONS);
+
+    If.RegisterInputKey("epsg_guard", &lc.epsg_guard, 0.0, 1.0e-5, 1.0e-7,
+            CHECK_AND_FIX, OPTIONAL,
+            "GGA guard value for low density regions. ",
+            "epsg_guard must lie in the range (0.0,1.0e-5). Ignoring. ", CONTROL_OPTIONS);
 
 
     // Booleans next. Booleans are never required.

--- a/Misc/check_tests.cpp
+++ b/Misc/check_tests.cpp
@@ -79,9 +79,26 @@ void check_tests(void)
             fprintf(elog, "deviation             : %15.8f Ha\n", eps);
             fprintf(elog, "tolerance             : %15.8f Ha\n", ct.test_energy_tolerance);
             if(eps < ct.test_energy_tolerance)
-                fprintf(elog, "test status: pass\n");
+            {
+                if(ct.test_steps)
+                {
+                    fprintf(elog, "reference steps to converge: %6d Ha\n", ct.test_steps);
+                    fprintf(elog, "current   steps to converge: %6d Ha\n", ct.scf_steps);
+                    fprintf(elog, "tolerance                  : %6d Ha\n", ct.test_steps_tolerance);
+                    if(ct.scf_steps > (ct.test_steps + ct.test_steps_tolerance))
+                        fprintf(elog, "test status: fail\n");
+                    else
+                        fprintf(elog, "test status: pass\n");
+                }
+                else
+                {
+                    fprintf(elog, "test status: pass\n");
+                }
+            }
             else
+            {
                 fprintf(elog, "test status: fail\n");
+            }
         }
 
         // Bond length test. Always performed between the first and second atoms

--- a/tests/RMG/AlN32/input
+++ b/tests/RMG/AlN32/input
@@ -1,6 +1,9 @@
 # Description of run.
 # Energy test
 test_energy="-215.98548688"
+test_steps = "14"
+test_steps_tolerance = "1"
+
 
 description="AlN 32 atom wurtzite test cell"
 localize_projectors="false"

--- a/tests/RMG/C60/input
+++ b/tests/RMG/C60/input
@@ -3,6 +3,9 @@ description="C60 test example using Davidson diagonalization"
 
 # Used to compare test energy
 test_energy="-343.84736795"
+test_steps = "15"
+test_steps_tolerance = "1"
+
 
 # Wavefunction grid
 wavefunction_grid="48 48 48"

--- a/tests/RMG/Diamond16/input
+++ b/tests/RMG/Diamond16/input
@@ -10,6 +10,8 @@
 # Description of run. Default: "QMD run"
 description="Diamond 16 atom test cell"
 test_energy = "-91.81035226"
+test_steps = "9"
+test_steps_tolerance = "2"
 
 # Wavefunction grid
 wavefunction_grid="32 32 32"

--- a/tests/RMG/Diamond2/input
+++ b/tests/RMG/Diamond2/input
@@ -10,6 +10,9 @@ compressed_infile = "false"
 compressed_outfile = "false"
 
 test_energy = "-11.38920211"
+test_steps = "9"
+test_steps_tolerance = "2"
+
 
 # Wavefunction grid
 wavefunction_grid="16 16 16"

--- a/tests/RMG/Fe_2atom/input
+++ b/tests/RMG/Fe_2atom/input
@@ -1,6 +1,9 @@
 # Iron test cell.
 #
 test_energy="-250.34837757"
+test_steps = "37"
+test_steps_tolerance = "4"
+
 
 # The normal process is to set thread counts via environment variables
 # but since the tests run in a batch via CTest we set some of them in

--- a/tests/RMG/Mg_2atom/input
+++ b/tests/RMG/Mg_2atom/input
@@ -1,6 +1,9 @@
 # Mg 2-atom test cell with k-points
 # Expected energy
 test_energy="-108.64670076"
+test_steps = "13"
+test_steps_tolerance = "1"
+
 
 
 a_length="      3.19405000"

--- a/tests/RMG/NiO8/input
+++ b/tests/RMG/NiO8/input
@@ -2,6 +2,9 @@
 description="NiO 8 atom cell in anti-ferromagnetic configuration solved using Davidson diagonalization"
 test_energy="-677.73679120"
 test_energy_tolerance="1.0e-7"
+test_steps = "16"
+test_steps_tolerance = "2"
+
 
 # Uncommenting this will print out more information
 #verbose="true"

--- a/tests/RMG/Pt-bulk-spinorbit/input
+++ b/tests/RMG/Pt-bulk-spinorbit/input
@@ -2,6 +2,9 @@
 description="atom_Pt_pp"
 
 test_energy="-45.09801696"
+test_steps = "9"
+test_steps_tolerance = "1"
+
 
 #spin_polarization="true"
 

--- a/tests/RMG/Re_2atom/input
+++ b/tests/RMG/Re_2atom/input
@@ -1,6 +1,9 @@
 # Rhenium test cell. Structure is HCP with gamma=60
 #
 test_energy = "-159.84996716"
+test_steps = "10"
+test_steps_tolerance = "1"
+
 
 lattice_vector = "
     2.77447000        0.00000000        0.00000000

--- a/tests/RMG/atomO_polarized/input
+++ b/tests/RMG/atomO_polarized/input
@@ -4,6 +4,9 @@ description="atom_O_pp"
 # Expected test energy
 test_energy="-15.87872917"
 test_energy_tolerance = "1.00000000e-06"
+test_steps = "9"
+test_steps_tolerance = "1"
+
 
 #spin_polarization="true"
 

--- a/tests/RMG/graphene/input
+++ b/tests/RMG/graphene/input
@@ -8,6 +8,9 @@ localize_localpp = "false"
 localize_projectors = "false"
 
 test_energy = "-12.04904321"
+test_steps = "11"
+test_steps_tolerance = "1"
+
 
   
 #******* CONTROL OPTIONS *******  


### PR DESCRIPTION
The energy tests were unable to detect regressions that affected convergence. This PR adds test options for the expected number of SCF steps and if more steps are required than specified the test will fail.